### PR TITLE
BuoyancyBody3D/BuoyancyProbe3D usability tweaks

### DIFF
--- a/addons/tessarakkt.oceanfft/components/BuoyancyBody3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyBody3D.gd
@@ -64,6 +64,11 @@ func add_probe(probe: BuoyancyProbe3D):
 	_buoyancy_probes.append(probe)
 	probe.ocean = ocean
 
+func remove_probe(probe: BuoyancyProbe3D):
+	var index := _buoyancy_probes.find(probe)
+	if index >= 0:
+		_buoyancy_probes.remove_at(index)
+
 func _integrate_forces(state):
 	if submerged:
 		linear_velocity *= 1.0 - submerged_drag_linear

--- a/addons/tessarakkt.oceanfft/components/BuoyancyBody3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyBody3D.gd
@@ -5,7 +5,6 @@ class_name BuoyancyBody3D
 ## Physics Body which is moved by 3D physics simulation, and interacts with
 ## buoyancy provided by an Ocean3D.
 
-
 ## Buoyancy force multiplier applied to all buoyancy probes.
 @export var buoyancy_multiplier := 1.0
 
@@ -19,17 +18,18 @@ class_name BuoyancyBody3D
 @export var submerged_drag_linear := 0.05
 @export var submerged_drag_angular := 0.1
 
-const _NO_PROBE_CONFIGURATION_WARNING :=\
-	"This node has no BuoyancyProbes so it cannot interact with an Ocean.
-	Consider adding a BuoyancyProbe3D as a child."
 
-
+## True if the body has at least one probe underwater.
 var submerged := false
+## Number of probes that are currently underwater.
 var submerged_probes := 0
 
-var _buoyancy_probes:Array[BuoyancyProbe3D] = []
 
+# Probes currently used in calculating this body's buoyancy
+var _buoyancy_probes:Array[BuoyancyProbe3D] = []
+# Used to only display the warning that the ocean is null once
 var _displayed_null_ocean_warning := false
+
 
 func _physics_process(delta:float) -> void:
 	if Engine.is_editor_hint():
@@ -60,20 +60,26 @@ func _physics_process(delta:float) -> void:
 #	linear_damp = submerged_drag_linear * (submerged_probes / _buoyancy_probes.size())
 #	angular_damp = submerged_drag_angular * (submerged_probes / _buoyancy_probes.size())
 
-func add_probe(probe: BuoyancyProbe3D):
-	_buoyancy_probes.append(probe)
-	probe.ocean = ocean
-
-func remove_probe(probe: BuoyancyProbe3D):
-	var index := _buoyancy_probes.find(probe)
-	if index >= 0:
-		_buoyancy_probes.remove_at(index)
-
 func _integrate_forces(state):
 	if submerged:
 		linear_velocity *= 1.0 - submerged_drag_linear
 		angular_velocity *= 1.0 - submerged_drag_angular
 
+## Adds a BuoyancyProbe3D to this body's buoyancy calculation.
+func add_probe(probe: BuoyancyProbe3D):
+	_buoyancy_probes.append(probe)
+	probe.ocean = ocean
+
+## Removes a BuoyancyProbe3D to this body's buoyancy calculation.
+func remove_probe(probe: BuoyancyProbe3D):
+	var index := _buoyancy_probes.find(probe)
+	if index >= 0:
+		_buoyancy_probes.remove_at(index)
+
 func _get_configuration_warnings():
+	const _NO_PROBE_CONFIGURATION_WARNING :=\
+		"This node has no BuoyancyProbes so it cannot interact with an Ocean.
+		Consider adding a BuoyancyProbe3D as a child."
+
 	if _buoyancy_probes.is_empty():
 		return [_NO_PROBE_CONFIGURATION_WARNING]

--- a/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
@@ -3,6 +3,7 @@
 extends Marker3D
 class_name BuoyancyProbe3D
 ## Buoyancy probe used by BuoyancyBody3D to approximate an objects buoyancy.
+##
 ## This is used as a wave height sampler by BuoyancyBody3D in order to do
 ## buoyancy calculations. It has no effect on its own, and must be added to a
 ## buoyancy body in order to provide an effect. This could also be used as a

--- a/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
@@ -29,7 +29,7 @@ class_name BuoyancyProbe3D
 ## to this probe. If the probe is added to the body after _ready(), the ocean
 ## will need to be manually assigned.
 var ocean:Ocean3D
-var _has_buoyancy_body := false
+var _buoyancy_body : BuoyancyBody3D = null
 
 const _NO_BODY_CONFIGURATION_WARNING :=\
 	"BuoyancyProbe3D only serves to provide a buoyancy probe to a BuoyancyBody3D derived node.
@@ -39,20 +39,23 @@ const _NO_BODY_CONFIGURATION_WARNING :=\
 func get_wave_height() -> float:
 	return ocean.get_wave_height(global_position, max_cascade, height_sampling_steps)
 
-func _ready():
-	_register_with_buoyancy_body_3d_parent()
-	tree_entered.connect(_register_with_buoyancy_body_3d_parent)
-
 func _register_with_buoyancy_body_3d_parent():
 	var parent := get_parent()
 	while parent:
 		if parent is BuoyancyBody3D:
 			parent.add_probe(self)
-			_has_buoyancy_body = true
+			_buoyancy_body = parent
 			return
 		parent = parent.get_parent()
-	_has_buoyancy_body = false
+	_buoyancy_body = null
+
+func _enter_tree():
+	_register_with_buoyancy_body_3d_parent()
+
+func _exit_tree():
+	if _buoyancy_body:
+		_buoyancy_body.remove_probe(self)
 
 func _get_configuration_warnings():
-	if !_has_buoyancy_body:
+	if !_buoyancy_body:
 		return [_NO_BODY_CONFIGURATION_WARNING]

--- a/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
@@ -1,3 +1,4 @@
+@tool
 @icon("res://addons/tessarakkt.oceanfft/icons/BuoyancyProbe3D.svg")
 extends Marker3D
 class_name BuoyancyProbe3D
@@ -28,8 +29,30 @@ class_name BuoyancyProbe3D
 ## to this probe. If the probe is added to the body after _ready(), the ocean
 ## will need to be manually assigned.
 var ocean:Ocean3D
+var _has_buoyancy_body := false
 
+const _NO_BODY_CONFIGURATION_WARNING :=\
+	"BuoyancyProbe3D only serves to provide a buoyancy probe to a BuoyancyBody3D derived node.
+	Please ensure a BuoyancyBody3D is above it in the tree (e.g. as a parent, grandparent, etc)"
 
 ## Get the wave height at this buoyancy probes's location.
 func get_wave_height() -> float:
 	return ocean.get_wave_height(global_position, max_cascade, height_sampling_steps)
+
+func _ready():
+	_register_with_buoyancy_body_3d_parent()
+	tree_entered.connect(_register_with_buoyancy_body_3d_parent)
+
+func _register_with_buoyancy_body_3d_parent():
+	var parent := get_parent()
+	while parent:
+		if parent is BuoyancyBody3D:
+			parent.add_probe(self)
+			_has_buoyancy_body = true
+			return
+		parent = parent.get_parent()
+	_has_buoyancy_body = false
+
+func _get_configuration_warnings():
+	if !_has_buoyancy_body:
+		return [_NO_BODY_CONFIGURATION_WARNING]

--- a/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
@@ -3,7 +3,6 @@
 extends Marker3D
 class_name BuoyancyProbe3D
 ## Buoyancy probe used by BuoyancyBody3D to approximate an objects buoyancy.
-##
 ## This is used as a wave height sampler by BuoyancyBody3D in order to do
 ## buoyancy calculations. It has no effect on its own, and must be added to a
 ## buoyancy body in order to provide an effect. This could also be used as a

--- a/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
@@ -23,12 +23,14 @@ class_name BuoyancyProbe3D
 @export_range(0, 2, 1) var max_cascade := 1
 
 
-## The ocean simulation that will be sampled for wave height. If this is a child
-## of a BuoyancyBody3D's BuoyancyProbes container node when
-## BuoyancyBody3D._ready() is called, the bodies assigned ocean will be assigned
-## to this probe. If the probe is added to the body after _ready(), the ocean
-## will need to be manually assigned.
+## The ocean simulation that will be sampled for wave height. If this is a descendant
+## of a BuoyancyBody3D node, that bodies' assigned ocean will be assigned
+## to this probe.
 var ocean:Ocean3D
+
+## The BuoyancyBody3D this probe is being used by. Assigned automatically by seeking
+## up the tree for a BuoyancyBody3D upon being added to the tree, and removed
+## automatically when exiting the tree
 var _buoyancy_body : BuoyancyBody3D = null
 
 const _NO_BODY_CONFIGURATION_WARNING :=\

--- a/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
+++ b/addons/tessarakkt.oceanfft/components/BuoyancyProbe3D.gd
@@ -23,25 +23,23 @@ class_name BuoyancyProbe3D
 @export_range(0, 2, 1) var max_cascade := 1
 
 
-## The ocean simulation that will be sampled for wave height. If this is a descendant
-## of a BuoyancyBody3D node, that bodies' assigned ocean will be assigned
+## The ocean simulation that will be sampled for wave height. If this probe is
+## added to a BuoyancyBody3D node, that bodies' assigned ocean will be assigned
 ## to this probe.
 var ocean:Ocean3D
 
-## The BuoyancyBody3D this probe is being used by. Assigned automatically by seeking
-## up the tree for a BuoyancyBody3D upon being added to the tree, and removed
-## automatically when exiting the tree
+# The BuoyancyBody3D this probe is being used by. Assigned automatically by seeking
+# up the tree for a BuoyancyBody3D upon being added to the tree, and removed
+# automatically when exiting the tree
 var _buoyancy_body : BuoyancyBody3D = null
 
-const _NO_BODY_CONFIGURATION_WARNING :=\
-	"BuoyancyProbe3D only serves to provide a buoyancy probe to a BuoyancyBody3D derived node.
-	Please ensure a BuoyancyBody3D is above it in the tree (e.g. as a parent, grandparent, etc)"
 
 ## Get the wave height at this buoyancy probes's location.
 func get_wave_height() -> float:
 	return ocean.get_wave_height(global_position, max_cascade, height_sampling_steps)
 
-func _register_with_buoyancy_body_3d_parent():
+# Seeks up the scene tree for the first BuoyancyBody3D ancestor and adds itself to its active probes
+func _add_to_buoyancy_body_3d_ancestor():
 	var parent := get_parent()
 	while parent:
 		if parent is BuoyancyBody3D:
@@ -52,12 +50,16 @@ func _register_with_buoyancy_body_3d_parent():
 	_buoyancy_body = null
 
 func _enter_tree():
-	_register_with_buoyancy_body_3d_parent()
+	_add_to_buoyancy_body_3d_ancestor()
 
 func _exit_tree():
 	if _buoyancy_body:
 		_buoyancy_body.remove_probe(self)
 
 func _get_configuration_warnings():
+	const _NO_BODY_CONFIGURATION_WARNING :=\
+		"BuoyancyProbe3D only serves to provide a buoyancy probe to a BuoyancyBody3D derived node.
+		Please ensure it has a BuoyancyBody3D as an ancestor in the scene tree"
+
 	if !_buoyancy_body:
 		return [_NO_BODY_CONFIGURATION_WARNING]

--- a/addons/tessarakkt.oceanfft/components/MotorVesselBody3D.gd
+++ b/addons/tessarakkt.oceanfft/components/MotorVesselBody3D.gd
@@ -1,3 +1,4 @@
+@tool
 @icon("res://addons/tessarakkt.oceanfft/icons/MotorVesselBody3D.svg")
 extends BuoyancyBody3D
 class_name MotorVesselBody3D
@@ -15,6 +16,11 @@ class_name MotorVesselBody3D
 
 
 func _process(delta):
+	if Engine.is_editor_hint():
+		return
+	if !ocean:
+		# Prints BuoyancyBody3D warning from its _physics_process, no need to warn again here
+		return
 	if ocean.get_wave_height(propeller.global_position) > propeller.global_position.y:
 		var prop_horizontal := -global_transform.basis.z
 		prop_horizontal.y = 0.0


### PR DESCRIPTION
- BuoyancyProbe3D uses `_enter_tree` and `_exit_tree` callbacks to seek closest
  BuoyancyBody3D parent and add/remove itself as a probe for that body
- BuoyancyBody3D no longer reference hard-coded '$BuoyancyProbes' probe parent
- If a BuoyancyProbe3D cannot find a BuoyancyBody3D parent it displays a
  node configuration warning in editor
- If a BuoyancyBody3D has no registered BuoyancyProbe3Ds it displays a
  node configuration warning in editor
- BuoyancyProbe3D, BuoyancyBody3D, MotorVessel3D are now tool scripts to facilitate
  all this
- BuoyancyBody3D and MoterVessel3D more gracefully handle when their `ocean` property is null by printing a warning once during runtime
- This change is backwards compatible - any configuration that worked before will still work now